### PR TITLE
Ignore required status checks for release PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - master
+      - "!changeset-release/**"
 
 jobs:
   build:


### PR DESCRIPTION
Currently the release PR #40 cannot be merged, because the required status checks are not triggered. This PR excludes the changeset branches from the CI.