### PR TITLE
Fix endless rerenders in MapExplorer

### DIFF
--- a/packages/v8-deopt-webapp/src/components/V8DeoptInfoPanel/MapExplorer.jsx
+++ b/packages/v8-deopt-webapp/src/components/V8DeoptInfoPanel/MapExplorer.jsx
@@ -296,7 +296,12 @@ export function MapExplorer(props) {
 				setSelectedEntry(null);
 			}
 		}
-	}, [state.selectedGroup, fileDeoptInfo]);
+	}, [
+		state.selectedGroup.group,
+		state.selectedGroup.id,
+		state.selectedGroup.label,
+		fileDeoptInfo,
+	]);
 
 	return (
 		<Fragment>


### PR DESCRIPTION
Right now MapExplorer has a problem that leads to endless rerenders:
- [`const state = initGroupingState(props)`](https://github.com/andrewiggins/v8-deopt-viewer/blob/master/packages/v8-deopt-webapp/src/components/V8DeoptInfoPanel/MapExplorer.jsx#L270) every time has a new property `state.selectedGroup` because objects for groups are created every time from scratch at [`getGroupingValues()`](https://github.com/andrewiggins/v8-deopt-viewer/blob/master/packages/v8-deopt-webapp/src/components/V8DeoptInfoPanel/MapExplorer.jsx#L560), there is no caching or memoization
- `useEffect()` [relies](https://github.com/andrewiggins/v8-deopt-viewer/blob/master/packages/v8-deopt-webapp/src/components/V8DeoptInfoPanel/MapExplorer.jsx#L299) on `[state.selectedGroup, fileDeoptInfo]`, but `state.selectedGroup` on every render is different, so shallow compare with previous version will return false even when deep compare would show they are similar; therefore `useEffect()` is called on each rerender
- after the render `useEffect()` may call `setSelectedEntry(state.selectedGroup.entry)`, starting endless rerender loop

Schematically, the execution loop has next steps:
```js
MapExplorer() // render
const state = initGroupingState(props); // create new object instance for state.selectedGroup
useEffect(/*...*/, [state.selectedGroup, fileDeoptInfo]) // trigger useEffect because shallow equality check fails for state.selectedGroup
useEffect(() => {/*...*/setSelectedEntry(state.selectedGroup.entry);/*...*/}) // trigger new rerender
MapExplorer() // rerender -> loop
```
