### PR TITLE
Fix prism.css styles

### DIFF
--- a/.changeset/quiet-zebras-obey.md
+++ b/.changeset/quiet-zebras-obey.md
@@ -1,0 +1,5 @@
+---
+"v8-deopt-webapp": patch
+---
+
+Fix Prism.css styles

--- a/package-lock.json
+++ b/package-lock.json
@@ -6253,6 +6253,9 @@
       },
       "bin": {
         "v8-deopt-viewer": "bin/v8-deopt-viewer.js"
+      },
+      "devDependencies": {
+        "tape": "^5.0.0"
       }
     },
     "packages/v8-deopt-webapp": {
@@ -10625,6 +10628,7 @@
         "httpie": "^1.1.2",
         "open": "^8.4.0",
         "sade": "^1.8.1",
+        "tape": "^5.0.0",
         "v8-deopt-generate-log": "^0.2.0",
         "v8-deopt-parser": "^0.4.0",
         "v8-deopt-webapp": "^0.4.0"

--- a/packages/v8-deopt-webapp/src/components/CodePanel.jsx
+++ b/packages/v8-deopt-webapp/src/components/CodePanel.jsx
@@ -8,12 +8,16 @@ import {
 import { memo, forwardRef } from "preact/compat";
 import Prism from "prismjs";
 import { addDeoptMarkers, getMarkerId } from "../utils/deoptMarkers";
+import { useAppDispatch, useAppState } from "./appState";
+
+// Styles - order matters. prism.scss must come first so its styles can be
+// overridden by other files
+import "../prism.scss";
 import { codePanel, error as errorClass } from "./CodePanel.module.scss";
 import {
 	showLowSevs as showLowSevsClass,
 	active,
 } from "../utils/deoptMarkers.module.scss";
-import { useAppDispatch, useAppState } from "./appState";
 
 // Turn on auto highlighting by Prism
 Prism.manual = true;

--- a/packages/v8-deopt-webapp/src/components/CodePanel.module.scss
+++ b/packages/v8-deopt-webapp/src/components/CodePanel.module.scss
@@ -1,7 +1,4 @@
 :global {
-	@import "~prismjs/themes/prism.css";
-	@import "~prismjs/plugins/line-numbers/prism-line-numbers.css";
-
 	//*******************************
 	// Prism overrides
 	//*******************************

--- a/packages/v8-deopt-webapp/src/prism.scss
+++ b/packages/v8-deopt-webapp/src/prism.scss
@@ -1,0 +1,2 @@
+@import "prismjs/themes/prism.css";
+@import "prismjs/plugins/line-numbers/prism-line-numbers.css";

--- a/packages/v8-deopt-webapp/vite.config.mjs
+++ b/packages/v8-deopt-webapp/vite.config.mjs
@@ -6,7 +6,7 @@ import { generateTestData } from "./test/generateTestData.mjs";
 export default defineConfig({
 	plugins: [
 		preact(),
-		// @ts-ignore Types are wrong
+		// @ts-expect-error Types are wrong
 		visualizer.default({
 			filename: "stats.html",
 			gzipSize: true,


### PR DESCRIPTION
The update to Vite changed how Sass modules are imported, breaking prism styles. This change includes Prism styles in a non-module file so they are applied globally and names aren't mangled.